### PR TITLE
issue-5

### DIFF
--- a/src/masterlock/masterlock.go
+++ b/src/masterlock/masterlock.go
@@ -12,14 +12,16 @@ type PartInfo struct {
 }
 
 type MasterLock struct {
-	Parts   []PartInfo `json:"parts"`
-	Padding int        `json:"padding"`
+	Parts        []PartInfo `json:"parts"`
+	FrontPadding int        `json:"front_padding"`
+	BackPadding  int        `json:"padding"`
 }
 
-func CreateMasterLock(parts []PartInfo, padding int) ([]byte, error) {
+func CreateMasterLock(parts []PartInfo, frontPadding int, backPadding int) ([]byte, error) {
 	masterLock := MasterLock{
-		Parts:   parts,
-		Padding: padding,
+		Parts:        parts,
+		FrontPadding: frontPadding,
+		BackPadding:  backPadding,
 	}
 
 	data, err := json.Marshal(masterLock)

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/voodooEntity/go-tachicrypt/src/prettywriter"
 	"golang.org/x/term"
+	"math/big"
 	"os"
 	"syscall"
 )
@@ -76,4 +77,29 @@ func ConcatByteSlices(byteSlices [][]byte) []byte {
 		offset += len(slice)
 	}
 	return result
+}
+
+func GenerateRandomBytes(min, max int) ([]byte, error) {
+	// Ensure min is less than or equal to max
+	if min > max {
+		min, max = max, min
+	}
+
+	// Generate a random number between min and max (inclusive)
+	randAmount, err := rand.Int(rand.Reader, big.NewInt(int64(max-min+1)))
+	if err != nil {
+		return nil, err
+	}
+	randAmount.Add(randAmount, big.NewInt(int64(min)))
+
+	// Create a byte slice of the desired length
+	randomBytes := make([]byte, int(randAmount.Int64()))
+
+	// Read random bytes into the slice
+	_, err = rand.Read(randomBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return randomBytes, nil
 }


### PR DESCRIPTION
Mitigate Cleartext option attack by adding a random padding to the front of the []byte data to obfuscate the zip headers position. 